### PR TITLE
add api endpoint to update org addresses

### DIFF
--- a/src/main/kotlin/io/billie/organisations/data/UnableToFindOrganisation.kt
+++ b/src/main/kotlin/io/billie/organisations/data/UnableToFindOrganisation.kt
@@ -1,0 +1,5 @@
+package io.billie.organisations.data
+
+import java.util.UUID
+
+class UnableToFindOrganisation (val id: UUID) : RuntimeException()

--- a/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
+++ b/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
@@ -2,6 +2,7 @@ package io.billie.organisations.resource
 
 import io.billie.organisations.data.UnableToFindCity
 import io.billie.organisations.data.UnableToFindCountry
+import io.billie.organisations.data.UnableToFindOrganisation
 import io.billie.organisations.service.OrganisationService
 import io.billie.organisations.viewmodel.*
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.util.*
@@ -54,4 +56,37 @@ class OrganisationResource(val service: OrganisationService) {
         }
     }
 
+    @PutMapping("{id}/contact-details")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Accepted the new contact details",
+                content = [
+                    (Content(
+                        mediaType = "application/json",
+                        array = (ArraySchema(schema = Schema(implementation = Entity::class)))
+                    ))]
+            ),
+            ApiResponse(responseCode = "400", description = "Bad request", content = [Content()])]
+    )
+    fun updateContactDetails(
+        @PathVariable("id") id: UUID,
+        @Valid @RequestBody contactDetails: ContactDetailsRequest
+    ): Entity {
+        try {
+            val contactDetailsId: UUID = service.updateContactDetails(id, contactDetails)
+            return Entity(contactDetailsId)
+        } catch (e: Exception) {
+            when (e) {
+                is UnableToFindCity -> {
+                    throw ResponseStatusException(BAD_REQUEST, e.message)
+                }
+                is UnableToFindOrganisation -> {
+                    throw ResponseStatusException(NOT_FOUND, e.message)
+                }
+                else -> throw e
+            }
+        }
+    }
 }

--- a/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
+++ b/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
@@ -1,6 +1,7 @@
 package io.billie.organisations.service
 
 import io.billie.organisations.data.OrganisationRepository
+import io.billie.organisations.viewmodel.ContactDetailsRequest
 import io.billie.organisations.viewmodel.OrganisationRequest
 import io.billie.organisations.viewmodel.OrganisationResponse
 import org.springframework.stereotype.Service
@@ -13,6 +14,13 @@ class OrganisationService(val db: OrganisationRepository) {
 
     fun createOrganisation(organisation: OrganisationRequest): UUID {
         return db.create(organisation)
+    }
+
+    /**
+     * Returns newly created contact details UUID
+     */
+    fun updateContactDetails(id: UUID, contactDetails: ContactDetailsRequest): UUID {
+        return db.updateContactDetails(id, contactDetails)
     }
 
 }

--- a/src/test/kotlin/io/billie/functional/UpdateOrganisationContactDetailsTest.kt
+++ b/src/test/kotlin/io/billie/functional/UpdateOrganisationContactDetailsTest.kt
@@ -1,0 +1,123 @@
+package io.billie.functional
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.billie.functional.utils.DbUtils.addressFromDatabase
+import io.billie.functional.utils.DbUtils.contactDetailsFromDatabase
+import io.billie.functional.utils.DbUtils.createAnOrganization
+import io.billie.functional.utils.DbUtils.orgFromDatabase
+import io.billie.functional.data.Fixtures.bbcAddressFixture
+import io.billie.functional.data.Fixtures.bbcContactFixture
+import io.billie.functional.data.Fixtures.updateContactDetailsRequest
+import io.billie.functional.data.Fixtures.updateContactDetailsRequestInvalidCity
+import io.billie.functional.data.Fixtures.updateContactDetailsRequestInvalidCountryCode
+import io.billie.functional.data.Fixtures.updateContactDetailsRequestMissingAddress
+import io.billie.functional.utils.Utils.assertDataMatches
+import io.billie.organisations.data.OrganisationRepository
+import io.billie.organisations.viewmodel.Entity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.*
+
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = DEFINED_PORT)
+class UpdateOrganisationContactDetailsTest {
+
+    @LocalServerPort
+    private val port = 8080
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mapper: ObjectMapper
+
+    @Autowired
+    private lateinit var template: JdbcTemplate
+
+    @Autowired
+    private lateinit var db: OrganisationRepository
+
+
+    @Test
+    fun returns404WhenOrgDoesNotExist() {
+        mockMvc.perform(
+            put("/organisations/${UUID.randomUUID()}/contact-details").contentType(APPLICATION_JSON)
+                .content(updateContactDetailsRequest())
+        )
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun cannotUpdateOrgWhenNoAddress() {
+        val organisationDetails: Map<String, Any> = createAnOrganization(db)
+        val orgId: UUID = organisationDetails["id"] as UUID
+
+        mockMvc.perform(
+            put("/organisations/${orgId}/contact-details").contentType(APPLICATION_JSON)
+                .content(updateContactDetailsRequestMissingAddress())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotUpdateOrgWhenAddressCityInvalid() {
+        val organisationDetails: Map<String, Any> = createAnOrganization(db)
+        val orgId: UUID = organisationDetails["id"] as UUID
+
+        mockMvc.perform(
+            put("/organisations/${orgId}/contact-details").contentType(APPLICATION_JSON)
+                .content(updateContactDetailsRequestInvalidCity())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotUpdateOrgWhenAddressCountryCodeInvalid() {
+        val organisationDetails: Map<String, Any> = createAnOrganization(db)
+        val orgId: UUID = organisationDetails["id"] as UUID
+
+        mockMvc.perform(
+            put("/organisations/${orgId}/contact-details").contentType(APPLICATION_JSON)
+                .content(updateContactDetailsRequestInvalidCountryCode())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun canUpdateContactDetails() {
+        val organisationDetails: Map<String, Any> = createAnOrganization(db)
+        val orgId: UUID = organisationDetails["id"] as UUID
+
+        val result = mockMvc.perform(
+            put("/organisations/${orgId}/contact-details").contentType(APPLICATION_JSON)
+                .content(updateContactDetailsRequest())
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val response = mapper.readValue(result.response.contentAsString, Entity::class.java)
+
+        val contactDetailsId: UUID = response.id
+        val contactDetails: Map<String, Any> = contactDetailsFromDatabase(template, contactDetailsId)
+        assertDataMatches(contactDetails, bbcContactFixture(contactDetailsId))
+
+        val addressId: UUID = UUID.fromString(contactDetails["address_id"] as String)
+        val addressDetails: Map<String, Any> = addressFromDatabase(template, addressId)
+        assertDataMatches(addressDetails, bbcAddressFixture(addressId))
+
+        val updatedOrganisationDetails: Map<String, Any> = orgFromDatabase(template, orgId)
+        val updatedContactId: UUID = UUID.fromString(updatedOrganisationDetails["contact_details_id"] as String)
+        assertEquals(contactDetailsId, updatedContactId)
+    }
+}

--- a/src/test/kotlin/io/billie/functional/data/Fixtures.kt
+++ b/src/test/kotlin/io/billie/functional/data/Fixtures.kt
@@ -246,6 +246,64 @@ object Fixtures {
                 "}"
     }
 
+    fun updateContactDetailsRequest(): String {
+        return "{\n" +
+                "   \"phone_number\": \"+443700100222\",\n" +
+                "   \"fax\": \"\",\n" +
+                "   \"email\": \"yourquestions@bbc.co.uk\",\n" +
+                "   \"address\": {\n" +
+                "       \"street\": \"Television Centre\",\n" +
+                "       \"house_number\": \"1\",\n" +
+                "       \"additional\": \"additional\",\n" +
+                "       \"zip_code\": \"W12 7FA\",\n" +
+                "       \"city\": \"London\",\n" +
+                "       \"country_code\": \"GB\"\n" +
+                "   }\n" +
+                "}"
+    }
+
+    fun updateContactDetailsRequestMissingAddress(): String {
+        return "{\n" +
+                "   \"phone_number\": \"+443700100222\",\n" +
+                "   \"fax\": \"\",\n" +
+                "   \"email\": \"yourquestions@bbc.co.uk\"\n" +
+                "}"
+    }
+
+    fun updateContactDetailsRequestInvalidCity(): String {
+        return "{\n" +
+                "   \"phone_number\": \"+443700100222\",\n" +
+                "   \"fax\": \"\",\n" +
+                "   \"email\": \"yourquestions@bbc.co.uk\",\n" +
+                "   \"address\": {\n" +
+                "       \"street\": \"Television Centre\",\n" +
+                "       \"house_number\": \"1\",\n" +
+                "       \"additional\": \"additional\",\n" +
+                "       \"zip_code\": \"W12 7FA\",\n" +
+                "       \"city\": \"does_not_exist\",\n" +
+                "       \"country_code\": \"GB\"\n" +
+                "   }\n" +
+                "}"
+    }
+
+
+    fun updateContactDetailsRequestInvalidCountryCode(): String {
+        return "{\n" +
+                "   \"phone_number\": \"+443700100222\",\n" +
+                "   \"fax\": \"\",\n" +
+                "   \"email\": \"yourquestions@bbc.co.uk\",\n" +
+                "   \"address\": {\n" +
+                "       \"street\": \"Television Centre\",\n" +
+                "       \"house_number\": \"1\",\n" +
+                "       \"additional\": \"additional\",\n" +
+                "       \"zip_code\": \"W12 7FA\",\n" +
+                "       \"city\": \"London\",\n" +
+                "       \"country_code\": \"DE\"\n" +
+                "   }\n" +
+                "}"
+    }
+
+
     fun bbcFixture(id: UUID): Map<String, Any> {
         val data = HashMap<String, Any>()
         data["id"] = id

--- a/src/test/kotlin/io/billie/functional/utils/DbUtils.kt
+++ b/src/test/kotlin/io/billie/functional/utils/DbUtils.kt
@@ -1,0 +1,32 @@
+package io.billie.functional.utils
+
+import io.billie.functional.utils.Utils.anOrganizationRequest
+import io.billie.organisations.data.OrganisationRepository
+import io.billie.organisations.viewmodel.OrganisationRequest
+import org.springframework.jdbc.core.JdbcTemplate
+import java.util.*
+
+object DbUtils {
+
+    fun createAnOrganization(
+        db: OrganisationRepository,
+        request: OrganisationRequest = anOrganizationRequest()
+    ): MutableMap<String, Any> {
+        val id: UUID = db.create(request)
+
+        return orgFromDatabase(db.jdbcTemplate, id)
+    }
+
+    fun queryEntityFromDatabase(template: JdbcTemplate, sql: String, id: UUID): MutableMap<String, Any> =
+        template.queryForMap(sql, id)
+
+    fun orgFromDatabase(template: JdbcTemplate, id: UUID): MutableMap<String, Any> =
+        queryEntityFromDatabase(template, "select * from organisations_schema.organisations where id = ?", id)
+
+    fun contactDetailsFromDatabase(template: JdbcTemplate, id: UUID): MutableMap<String, Any> =
+        queryEntityFromDatabase(template, "select * from organisations_schema.contact_details where id = ?", id)
+
+    fun addressFromDatabase(template: JdbcTemplate, id: UUID): MutableMap<String, Any> =
+        queryEntityFromDatabase(template, "select * from organisations_schema.addresses where id = ?", id)
+
+}

--- a/src/test/kotlin/io/billie/functional/utils/Utils.kt
+++ b/src/test/kotlin/io/billie/functional/utils/Utils.kt
@@ -1,0 +1,71 @@
+package io.billie.functional.utils
+
+import io.billie.organisations.viewmodel.AddressRequest
+import io.billie.organisations.viewmodel.ContactDetailsRequest
+import io.billie.organisations.viewmodel.LegalEntityType
+import io.billie.organisations.viewmodel.OrganisationRequest
+import org.hamcrest.MatcherAssert
+import org.hamcrest.core.IsEqual
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+object Utils {
+    fun assertDataMatches(reply: Map<String, Any>, assertions: Map<String, Any>) {
+        for (key in assertions.keys) {
+            MatcherAssert.assertThat(reply[key], IsEqual.equalTo(assertions[key]))
+        }
+    }
+
+    fun anOrganizationRequest(
+        name: String = "test_org_name",
+        dateFounded: LocalDate = LocalDate.parse("01/01/2023", DateTimeFormatter.ofPattern("dd/MM/yyy")),
+        countryCode: String = "GB",
+        vatNumber: String = "123456",
+        registrationNumber: String = "654321",
+        legalEntityType: LegalEntityType = LegalEntityType.SOLE_PROPRIETORSHIP,
+        contactDetailsRequest: ContactDetailsRequest = aContactDetailRequest()
+    ): OrganisationRequest {
+        return OrganisationRequest(
+            name,
+            dateFounded,
+            countryCode,
+            vatNumber,
+            registrationNumber,
+            legalEntityType,
+            contactDetailsRequest
+        )
+    }
+
+    fun aContactDetailRequest(
+        phoneNumber: String = "11111111",
+        fax: String = "22222222",
+        email: String = "test@example.com",
+        addressRequest: AddressRequest = anAddressRequest()
+    ): ContactDetailsRequest {
+        return ContactDetailsRequest(
+            phoneNumber,
+            fax,
+            email,
+            addressRequest
+        )
+    }
+
+    fun anAddressRequest(
+        street: String = "test street",
+        houseNumber: String = "123",
+        additional: String = "additional",
+        zipCode: String = "zipcode",
+        city: String = "London",
+        countryCode: String = "GB"
+    ): AddressRequest {
+        return AddressRequest(
+            street,
+            houseNumber,
+            additional,
+            zipCode,
+            city,
+            countryCode
+        )
+    }
+
+}


### PR DESCRIPTION
- Add API endpoint `PUT organisations/{id}/contact-details` to allow organisations to edit their contact address
- Add tests for the new endpoint
- Move test utility method around, since they are shared now